### PR TITLE
Fix gem dependency and change serializer model invocation

### DIFF
--- a/google_json_response.gemspec
+++ b/google_json_response.gemspec
@@ -20,13 +20,14 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
+  spec.add_dependency 'active_model_serializers', '>= 0.10.0.rc2'
+
   spec.add_development_dependency "bundler", "~> 1.13"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "activerecord"
   spec.add_development_dependency "sqlite3"
   spec.add_development_dependency "byebug"
-  spec.add_development_dependency 'active_model_serializers', '~> 0.10.0'
   spec.add_development_dependency "kaminari"
   spec.add_development_dependency "sequel"
 end

--- a/lib/google_json_response/record_parsers/parse_active_records.rb
+++ b/lib/google_json_response/record_parsers/parse_active_records.rb
@@ -61,7 +61,7 @@ module GoogleJsonResponse
           include: "",
           current_member: {}
         )
-        ActiveModelSerializers::SerializableResource.new(
+        ActiveModel::SerializableResource.new(
           collection,
           options
         ).as_json
@@ -74,7 +74,7 @@ module GoogleJsonResponse
           include: "",
           current_member: {}
         )
-        ActiveModelSerializers::SerializableResource.new(
+        ActiveModel::SerializableResource.new(
           resource,
           options
         ).as_json

--- a/lib/google_json_response/record_parsers/parse_sequel_records.rb
+++ b/lib/google_json_response/record_parsers/parse_sequel_records.rb
@@ -60,7 +60,7 @@ module GoogleJsonResponse
           include: "",
           current_member: {}
         )
-        ActiveModelSerializers::SerializableResource.new(
+        ActiveModel::SerializableResource.new(
           collection,
           options
         ).as_json
@@ -73,7 +73,7 @@ module GoogleJsonResponse
           include: "",
           current_member: {}
         )
-        ActiveModelSerializers::SerializableResource.new(
+        ActiveModel::SerializableResource.new(
           resource,
           options
         ).as_json

--- a/lib/google_json_response/version.rb
+++ b/lib/google_json_response/version.rb
@@ -1,3 +1,3 @@
 module GoogleJsonResponse
-  VERSION = "0.1.3"
+  VERSION = "0.1.4"
 end


### PR DESCRIPTION
Using this gem with our main app will raise uninitialize constant `ActiveModelSerializers::SerializableResource` error because version mismatching. This gem is to fix the gem dependency to 0.10.0-rc2

Changing the gem version resulted in some code changes related to switching `ActiveModelSerializers::SerializableResource` to `ActiveModel::SerializableResource`

Refs:
![Screen Shot 2019-04-22 at 2 01 57 PM](https://user-images.githubusercontent.com/3113120/56488011-48ad3c80-6507-11e9-8366-066ad77a24d2.png)

![Screen Shot 2019-04-22 at 2 02 07 PM](https://user-images.githubusercontent.com/3113120/56488015-4cd95a00-6507-11e9-8fa3-e7be153e7bc1.png)
