### PR TITLE
Apply version switcher to get the correct serializable resource class

### DIFF
--- a/google_json_response.gemspec
+++ b/google_json_response.gemspec
@@ -20,8 +20,6 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'active_model_serializers', '>= 0.10.0.rc2'
-
   spec.add_development_dependency "bundler", "~> 1.13"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
@@ -30,4 +28,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "byebug"
   spec.add_development_dependency "kaminari"
   spec.add_development_dependency "sequel"
+  spec.add_development_dependency 'active_model_serializers', '>= 0.10.0'
 end

--- a/lib/google_json_response/record_parsers/parse_active_records.rb
+++ b/lib/google_json_response/record_parsers/parse_active_records.rb
@@ -6,18 +6,11 @@ rescue LoadError
   raise "This module requires active_record and active_model_serializers"
 end
 
+require 'google_json_response/record_parsers/parser_base'
+
 module GoogleJsonResponse
   module RecordParsers
-    class ParseActiveRecords
-      attr_reader :parsed_data
-
-      def initialize(data, options = {})
-        @serializer_klass = options[:serializer_klass]
-        @custom_data = options[:custom_data] || {}
-        @options = options.except(:serializer_klass, :custom_data)
-        @data = data
-      end
-
+    class ParseActiveRecords < ParserBase
       def call
         parsed_resource = serializable_resource(@data, @serializer_klass, @options)
 
@@ -61,7 +54,7 @@ module GoogleJsonResponse
           include: "",
           current_member: {}
         )
-        ActiveModel::SerializableResource.new(
+        serializable_resource_klass.new(
           collection,
           options
         ).as_json
@@ -74,7 +67,7 @@ module GoogleJsonResponse
           include: "",
           current_member: {}
         )
-        ActiveModel::SerializableResource.new(
+        serializable_resource_klass.new(
           resource,
           options
         ).as_json

--- a/lib/google_json_response/record_parsers/parse_sequel_records.rb
+++ b/lib/google_json_response/record_parsers/parse_sequel_records.rb
@@ -5,18 +5,11 @@ rescue LoadError
   raise "This module requires sequel and active_model_serializers"
 end
 
+require 'google_json_response/record_parsers/parser_base'
+
 module GoogleJsonResponse
   module RecordParsers
-    class ParseSequelRecords
-      attr_reader :parsed_data
-
-      def initialize(data, options = {})
-        @serializer_klass = options[:serializer_klass]
-        @custom_data = options[:custom_data] || {}
-        @options = options.except(:serializer_klass, :custom_data)
-        @data = data
-      end
-
+    class ParseSequelRecords < ParserBase
       def call
         parsed_resource = serializable_resource(@data, @serializer_klass, @options)
 
@@ -60,7 +53,7 @@ module GoogleJsonResponse
           include: "",
           current_member: {}
         )
-        ActiveModel::SerializableResource.new(
+        serializable_resource_klass.new(
           collection,
           options
         ).as_json
@@ -73,7 +66,7 @@ module GoogleJsonResponse
           include: "",
           current_member: {}
         )
-        ActiveModel::SerializableResource.new(
+        serializable_resource_klass.new(
           resource,
           options
         ).as_json

--- a/lib/google_json_response/record_parsers/parser_base.rb
+++ b/lib/google_json_response/record_parsers/parser_base.rb
@@ -1,0 +1,28 @@
+module GoogleJsonResponse
+  module RecordParsers
+    class ParserBase
+      attr_reader :parsed_data
+
+      def initialize(data, options = {})
+        @serializer_klass = options[:serializer_klass]
+        @custom_data = options[:custom_data] || {}
+        @options = options.except(:serializer_klass, :custom_data)
+        @data = data
+      end
+
+      private
+
+      def serializable_resource_klass
+        version = Gem.loaded_specs["active_model_serializers"].version.to_s
+        klass_name =
+          case version
+          when '0.10.0.rc2' # Main app version. fixed for now!
+            'ActiveModel::SerializableResource'
+          else
+            'ActiveModelSerializers::SerializableResource'
+          end
+        Object.const_get(klass_name)
+      end
+    end
+  end
+end

--- a/lib/google_json_response/version.rb
+++ b/lib/google_json_response/version.rb
@@ -1,3 +1,3 @@
 module GoogleJsonResponse
-  VERSION = "0.1.4"
+  VERSION = "0.1.5"
 end


### PR DESCRIPTION
Since there are other services using this gem, the previous change would break them if they upgrade the gem version. This build is to fix the issue