### PR TITLE
Remove redundant methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ require "google_json_response/active_records"
 ```
 We can parse a single active record object
 ```ruby
-  GoogleJsonResponse.render_record(record_1, { serializer_klass: UserSerializer }).to_json
+  GoogleJsonResponse.render(record_1, { serializer_klass: UserSerializer }).to_json
 ```
 
 The result will be like this
@@ -142,12 +142,12 @@ The result will be like this
 
 We can parse an array of active records
 ```ruby
-  GoogleJsonResponse.render_records([record_1, record_2, record_3], { serializer_klass: UserSerializer, include: "**" }).to_json
+  GoogleJsonResponse.render([record_1, record_2, record_3], { serializer_klass: UserSerializer, include: "**" }).to_json
 ```
 
 We can parse a active record relation object
 ```ruby
-  GoogleJsonResponse.render_records(
+  GoogleJsonResponse.render(
     User.where(name: 'test'), 
     { serializer_klass: UserSerializer, custom_data: { sort: '+name', item_per_page: 10 } }
   ).to_json
@@ -234,7 +234,7 @@ end
 
 We can parse a single sequel record object
 ```ruby
-  GoogleJsonResponse.render_record(record_1, { serializer_klass: UserSerializer }).to_json
+  GoogleJsonResponse.render(record_1, { serializer_klass: UserSerializer }).to_json
 ```
 
 The result will be like this
@@ -250,12 +250,12 @@ The result will be like this
 
 We can parse an array of sequel records
 ```ruby
-  GoogleJsonResponse.render_records([record_1, record_2, record_3], { serializer_klass: UserSerializer, include: "**" }).to_json
+  GoogleJsonResponse.render([record_1, record_2, record_3], { serializer_klass: UserSerializer, include: "**" }).to_json
 ```
 
 We can parse a sequel dataset object
 ```ruby
-  GoogleJsonResponse.render_records(
+  GoogleJsonResponse.render(
     User.where(name: 'test'), 
     { serializer_klass: UserSerializer, custom_data: { sort: '+name' } }
   ).to_json

--- a/app.json
+++ b/app.json
@@ -1,6 +1,6 @@
 {
   "name": "google_json_response",
-  "version": "0.1.9",
+  "version": "0.2.0",
   "documents": [
     {
       "name": "Parser for APIs following Google JSON style",

--- a/lib/google_json_response.rb
+++ b/lib/google_json_response.rb
@@ -35,21 +35,9 @@ module GoogleJsonResponse
     end
 
     def render_error(data, options = {})
-      if data.is_a?(String)
-        render_generic_error(data, options[:code])
-      else
-        render(data, options)
-      end
-    end
-
-    def render_record(data, options = {})
+      return render_generic_error(data, options[:code]) if data.is_a?(String)
       render(data, options)
     end
-
-    def render_records(data, options = {})
-      render(data, options)
-    end
-
 
     private
 

--- a/lib/google_json_response/version.rb
+++ b/lib/google_json_response/version.rb
@@ -1,3 +1,3 @@
 module GoogleJsonResponse
-  VERSION = "0.1.9"
+  VERSION = "0.2.0"
 end

--- a/spec/google_json_response_spec.rb
+++ b/spec/google_json_response_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 
 describe GoogleJsonResponse do
-  describe ".render_record" do
+  describe ".render single record" do
     let(:service_double) { double({}) }
 
     after do
@@ -18,7 +18,7 @@ describe GoogleJsonResponse do
         expect(GoogleJsonResponse::RecordParsers::ParseActiveRecords).to receive(:new).with(record_1, { serializer: :test }).and_return(service_double)
         expect(service_double).to receive(:call)
         expect(service_double).to receive(:parsed_data).and_return({ data: 'test' })
-        response = GoogleJsonResponse.render_record(record_1, { serializer: :test })
+        response = GoogleJsonResponse.render(record_1, { serializer: :test })
         expect(response).to eq({ data: 'test' })
       end
     end
@@ -28,7 +28,7 @@ describe GoogleJsonResponse do
 
       it 'throws runtime errror' do
         expect {
-          response = GoogleJsonResponse.render_record(record_1, { serializer: :test })
+          response = GoogleJsonResponse.render(record_1, { serializer: :test })
         }.to raise_error(
                RuntimeError,
                "Please require google_json_response/active_records"\
@@ -38,7 +38,7 @@ describe GoogleJsonResponse do
     end
   end
 
-  describe ".render_records" do
+  describe ".render collections" do
     let(:service_double) { double({}) }
 
     after do
@@ -58,7 +58,7 @@ describe GoogleJsonResponse do
         expect(GoogleJsonResponse::RecordParsers::ParseActiveRecords).to receive(:new).with(record_relation, { serializer: :test }).and_return(service_double)
         expect(service_double).to receive(:call)
         expect(service_double).to receive(:parsed_data).and_return({ data: 'test' })
-        response = GoogleJsonResponse.render_records(record_relation, { serializer: :test })
+        response = GoogleJsonResponse.render(record_relation, { serializer: :test })
         expect(response).to eq({ data: 'test' })
       end
     end
@@ -69,7 +69,7 @@ describe GoogleJsonResponse do
 
       it 'throw runtime error' do
         expect {
-          GoogleJsonResponse.render_records(record_relation, { serializer: :test })
+          GoogleJsonResponse.render(record_relation, { serializer: :test })
         }.to raise_error(
                RuntimeError,
                "Please require google_json_response/active_records"\
@@ -88,7 +88,7 @@ describe GoogleJsonResponse do
         expect(GoogleJsonResponse::RecordParsers::ParseActiveRecords).to receive(:new).with(records, { serializer: :test }).and_return(service_double)
         expect(service_double).to receive(:call)
         expect(service_double).to receive(:parsed_data).and_return({ data: 'test' })
-        response = GoogleJsonResponse.render_records(records, { serializer: :test })
+        response = GoogleJsonResponse.render(records, { serializer: :test })
         expect(response).to eq({ data: 'test' })
       end
     end
@@ -106,7 +106,7 @@ describe GoogleJsonResponse do
         expect(GoogleJsonResponse::RecordParsers::ParseSequelRecords).to receive(:new).with(record_relation, { serializer: :test }).and_return(service_double)
         expect(service_double).to receive(:call)
         expect(service_double).to receive(:parsed_data).and_return({ data: 'test' })
-        response = GoogleJsonResponse.render_records(record_relation, { serializer: :test })
+        response = GoogleJsonResponse.render(record_relation, { serializer: :test })
         expect(response).to eq({ data: 'test' })
       end
     end
@@ -120,7 +120,7 @@ describe GoogleJsonResponse do
       let!(:record_relation) { Item.where(name: 'test') }
       it 'throw runtime error' do
         expect {
-          GoogleJsonResponse.render_records(record_relation, { serializer: :test })
+          GoogleJsonResponse.render(record_relation, { serializer: :test })
         }.to raise_error(
                RuntimeError,
                "Please require google_json_response/sequel_records"\
@@ -143,7 +143,7 @@ describe GoogleJsonResponse do
         expect(GoogleJsonResponse::RecordParsers::ParseSequelRecords).to receive(:new).with(records, { serializer: :test }).and_return(service_double)
         expect(service_double).to receive(:call)
         expect(service_double).to receive(:parsed_data).and_return({ data: 'test' })
-        response = GoogleJsonResponse.render_records(records, { serializer: :test })
+        response = GoogleJsonResponse.render(records, { serializer: :test })
         expect(response).to eq({ data: 'test' })
       end
     end


### PR DESCRIPTION
Because render_record and render_records are basically the same as render, i'm removing them both, which leaves only render remain

Update readme doc along the way