### PR TITLE
render an error array with mixed types

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,6 +1,6 @@
 {
   "name": "google_json_response",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "documents": [
     {
       "name": "Parser for APIs following Google JSON style",

--- a/lib/google_json_response/error_renderer.rb
+++ b/lib/google_json_response/error_renderer.rb
@@ -12,37 +12,56 @@ module GoogleJsonResponse
     end
 
     def call
-      parser.call
-      @rendered_content = parser.parsed_data
+      unless errors.is_a?(::Array)
+        parser = create_parser(errors)
+        parser.call
+        @rendered_content = parser.parsed_data
+      else
+        @rendered_content = parse_error_array(errors)
+      end
     end
 
     private
 
     attr_reader :errors
 
-    def parser
-      @parser ||=
-        if standard_error?
-          GoogleJsonResponse::ErrorParsers::ParseStandardError.new(errors)
-        elsif active_model_error?
-          GoogleJsonResponse::ErrorParsers::ParseActiveRecordError.new(errors, options)
-        else
-          GoogleJsonResponse::ErrorParsers::ParseGenericError.new(errors)
-        end
+    def parse_error_array(errors)
+      temp_parsed_data = {
+        error: {
+          errors: []
+        }
+      }
+      errors.each do |e| 
+        parser = create_parser(e)
+        parser.call
+        next if parser.parsed_data.blank?
+        temp_parsed_data[:error][:errors].push(*parser.parsed_data[:error][:errors])
+      end
+      temp_parsed_data
     end
 
-    def standard_error?
-      return true if errors.is_a?(StandardError)
+    def create_parser(input_errors)
+      if standard_error?(input_errors)
+        GoogleJsonResponse::ErrorParsers::ParseStandardError.new(input_errors)
+      elsif active_model_error?(input_errors)
+        GoogleJsonResponse::ErrorParsers::ParseActiveRecordError.new(input_errors, options)
+      else
+        GoogleJsonResponse::ErrorParsers::ParseGenericError.new(input_errors)
+      end
+    end
+
+    def standard_error?(input_errors)
+      return true if input_errors.is_a?(StandardError)
       false
     end
 
-    def active_model_error?
+    def active_model_error?(input_errors)
       return false unless defined?(::ActiveModel::Errors)
-      errors.is_a?(::ActiveModel::Errors)
+      input_errors.is_a?(::ActiveModel::Errors)
     end
 
-    def generic_error?
-      errors.is_a?(::String) || errors.is_a?(::Array)
+    def generic_error?(input_errors)
+      input_errors.is_a?(::String) || input_errors.is_a?(::Array)
     end
   end
 end

--- a/lib/google_json_response/version.rb
+++ b/lib/google_json_response/version.rb
@@ -1,3 +1,3 @@
 module GoogleJsonResponse
-  VERSION = "0.2.5"
+  VERSION = "0.2.6"
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,6 +5,7 @@ require 'active_record'
 require 'active_model_serializers'
 require 'sequel'
 require 'database_cleaner'
+require 'byebug'
 
 #Active record test data
 ActiveRecord::Base.establish_connection adapter: "sqlite3", database: ":memory:"


### PR DESCRIPTION
Before the upgrade 0.2.1 of Mr @monkeydl (https://github.com/Thinkei/google_json_response/pull/14/files#r330403502) , we could render error arrays of mixed types but that feature was removed after 0.2.1 accidently. 
It was by bad when I didn't write unit tests to cover this case and led to the wrong refactoring.
@longnh92 has raised this issue because he has the need of using a render like that.
Now it's the chance to fix my mistake 

https://github.com/Thinkei/google_json_response/issues/22

example
```ruby
response = GoogleJsonResponse.render_error(
[
StandardError.new("Error"), 
active_record_errors, 
"hello world"
]
)
```
result

```ruby
{:error=>
{:errors=>[{:reason=>"StandardError", :message=>"Error"}, 
{:reason=>:blank, :message=>"Please select an key before you submit", :location=>:key, :location_type=>:field}, 
{:message=>"Hello world"}]}}
```