### PR TITLE
Make it works with indifferent access

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,6 +1,6 @@
 {
   "name": "google_json_response",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "documents": [
     {
       "name": "Parser for APIs following Google JSON style",

--- a/lib/google_json_response/error_parsers/parse_active_record_error.rb
+++ b/lib/google_json_response/error_parsers/parse_active_record_error.rb
@@ -50,7 +50,7 @@ module GoogleJsonResponse
           end
           errors.full_messages_for(field)[index]
         else
-          errors.messages[field][index]
+          errors[field][index]
         end
       end
 

--- a/lib/google_json_response/version.rb
+++ b/lib/google_json_response/version.rb
@@ -1,3 +1,3 @@
 module GoogleJsonResponse
-  VERSION = "0.2.6"
+  VERSION = "0.2.7"
 end


### PR DESCRIPTION
`field` here is one of keys get from `errors.details`. It can be a string or symbol.
`errors.messages.keys` can be not same type with `errors.details.keys`
So to make it works well. I changes like this to support different access.
